### PR TITLE
Add basic dungeon progression and centered layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,19 +39,71 @@ class GameScene extends Phaser.Scene {
         super('Game');
         this.playerEnergy = 3;
         this.playerHP = 30;
+        this.money = 0;
         this.enemyHP = 20;
+        this.deck = ['Attaque', 'Attaque', 'Défense'];
+        this.rooms = [];
+        this.currentRoom = 0;
     }
 
     create() {
+        this.activeUI = [];
         this.hpText = this.add.text(10, 10, 'HP: ' + this.playerHP, { fontSize: '16px', color: '#fff' });
-        this.energyText = this.add.text(10, 30, 'Énergie: ' + this.playerEnergy, { fontSize: '16px', color: '#fff' });
-        this.enemyText = this.add.text(10, 50, 'HP Ennemi: ' + this.enemyHP, { fontSize: '16px', color: '#fff' });
+        this.moneyText = this.add.text(10, 30, 'Or: ' + this.money, { fontSize: '16px', color: '#fff' });
+        this.energyText = this.add.text(10, 50, '', { fontSize: '16px', color: '#fff' });
+        this.generateRooms(6);
+        this.nextRoom();
+    }
 
-        this.endTurnButton = this.add.text(700, 550, 'Fin du tour', { fontSize: '24px', backgroundColor: '#333', padding: 10 })
+    generateRooms(count) {
+        const types = ['fight', 'event', 'shop'];
+        for (let i = 0; i < count; i++) {
+            this.rooms.push({ type: Phaser.Utils.Array.GetRandom(types) });
+        }
+    }
+
+    clearUI() {
+        if (this.handGroup) {
+            this.handGroup.clear(true, true);
+            this.handGroup = null;
+        }
+        this.activeUI.forEach(o => o.destroy());
+        this.activeUI = [];
+    }
+
+    nextRoom() {
+        this.clearUI();
+        if (this.currentRoom >= this.rooms.length) {
+            this.add.text(400, 300, 'Fin du donjon!', { fontSize: '32px', color: '#0f0' }).setOrigin(0.5);
+            this.scene.pause();
+            return;
+        }
+        const room = this.rooms[this.currentRoom++];
+        if (room.type === 'fight') {
+            this.startFight();
+        } else if (room.type === 'shop') {
+            this.startShop();
+        } else {
+            this.startEvent();
+        }
+    }
+
+    startFight() {
+        this.enemyHP = 20;
+        this.playerEnergy = 3;
+        this.energyText.setText('Énergie: ' + this.playerEnergy);
+        this.enemyText = this.add.text(10, 70, 'HP Ennemi: ' + this.enemyHP, { fontSize: '16px', color: '#fff' });
+        this.activeUI.push(this.enemyText);
+        this.endTurnButton = this.add.text(650, 550, 'Fin du tour', { fontSize: '24px', backgroundColor: '#333', padding: 10 })
             .setInteractive();
         this.endTurnButton.on('pointerdown', () => this.endPlayerTurn());
+        this.activeUI.push(this.endTurnButton);
+        this.drawHand();
+    }
 
-        this.hand = ['Attaque', 'Défense', 'Sort'];
+    drawHand() {
+        const shuffled = Phaser.Utils.Array.Shuffle([...this.deck]);
+        this.hand = shuffled.slice(0, 3);
         this.displayHand();
     }
 
@@ -79,8 +131,13 @@ class GameScene extends Phaser.Scene {
         if (card === 'Attaque') {
             this.enemyHP -= 5;
             this.enemyText.setText('HP Ennemi: ' + this.enemyHP);
+        } else if (card === 'Défense') {
+            this.playerHP += 2;
+            this.hpText.setText('HP: ' + this.playerHP);
         }
-        // Handle other card types later
+        if (this.enemyHP <= 0) {
+            this.playerWin();
+        }
     }
 
     endPlayerTurn() {
@@ -91,18 +148,60 @@ class GameScene extends Phaser.Scene {
             return;
         }
         if (this.enemyHP <= 0) {
-            this.add.text(400, 300, 'Victoire!', { fontSize: '32px', color: '#0f0' }).setOrigin(0.5);
-            this.scene.pause();
+            this.playerWin();
             return;
         }
         this.playerEnergy = 3;
         this.energyText.setText('Énergie: ' + this.playerEnergy);
-        this.displayHand();
+        this.drawHand();
     }
 
     enemyAction() {
         this.playerHP -= 3;
         this.hpText.setText('HP: ' + this.playerHP);
+    }
+
+    playerWin() {
+        this.money += 10;
+        this.moneyText.setText('Or: ' + this.money);
+        const text = this.add.text(400, 300, 'Victoire! +10 or', { fontSize: '32px', color: '#0f0' }).setOrigin(0.5).setInteractive();
+        this.activeUI.push(text);
+        text.on('pointerdown', () => this.nextRoom());
+    }
+
+    startEvent() {
+        const events = [
+            () => { this.money += 5; this.moneyText.setText('Or: ' + this.money); return 'Vous trouvez 5 or'; },
+            () => { this.playerHP = Math.max(1, this.playerHP - 5); this.hpText.setText('HP: ' + this.playerHP); return 'Un piège! -5 HP'; }
+        ];
+        const result = Phaser.Utils.Array.GetRandom(events)();
+        const text = this.add.text(400, 300, result, { fontSize: '24px', color: '#fff', backgroundColor: '#333', padding: 10 }).setOrigin(0.5).setInteractive();
+        this.activeUI.push(text);
+        text.on('pointerdown', () => this.nextRoom());
+    }
+
+    startShop() {
+        const title = this.add.text(400, 100, 'Marchand', { fontSize: '28px', color: '#fff' }).setOrigin(0.5);
+        this.activeUI.push(title);
+        const cards = ['Attaque', 'Défense'];
+        cards.forEach((card, i) => {
+            const option = this.add.text(300, 200 + i * 60, card + ' - 10 or', {
+                fontSize: '20px', backgroundColor: '#222', padding: 10
+            }).setInteractive();
+            option.on('pointerdown', () => {
+                if (this.money >= 10) {
+                    this.money -= 10;
+                    this.moneyText.setText('Or: ' + this.money);
+                    this.deck.push(card);
+                    option.destroy();
+                }
+            });
+            this.activeUI.push(option);
+        });
+        const cont = this.add.text(400, 500, 'Continuer', { fontSize: '24px', backgroundColor: '#333', padding: 10 })
+            .setOrigin(0.5).setInteractive();
+        cont.on('pointerdown', () => this.nextRoom());
+        this.activeUI.push(cont);
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -4,11 +4,15 @@ body {
     background: #111;
     color: #fff;
     font-family: Arial, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
 }
 
 #game {
-    width: 100vw;
-    height: 100vh;
+    width: 800px;
+    height: 600px;
 }
 
 .menu-button {


### PR DESCRIPTION
## Summary
- center the game canvas with CSS
- add money, deck and room management
- implement simple shop and random events between fights
- reward coins for victories

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68499925dbf8832c8a635c7cda8ef2b4