### PR TITLE
Add dungeon rooms and gold system

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
             <button id="how-to-play">How to Play</button>
         </div>
 
+        <div id="gold-display" class="hidden">Gold: 0</div>
+
         <div id="tutorial-screen" class="hidden">
             <h2>How to Play</h2>
             <p>Welcome to Card Battler: The Sequel! Here's how to play:</p>
@@ -24,6 +26,12 @@
                 <li>Create powerful card combinations</li>
             </ul>
             <button id="tutorial-back">Back to Menu</button>
+        </div>
+
+        <div id="dungeon-screen" class="hidden">
+            <h2>Choose Your Room</h2>
+            <div id="room-options"></div>
+            <div id="upcoming-rooms">Upcoming: <span id="upcoming-1"></span> -> <span id="upcoming-2"></span></div>
         </div>
 
         <div id="game-screen" class="hidden">
@@ -80,9 +88,8 @@
 
         <div id="reward-screen" class="hidden">
             <h2>Victory!</h2>
-            <p>Choose a card to add to your deck:</p>
-            <div id="reward-cards"></div>
-            <button id="skip-reward">Skip Reward</button>
+            <p id="reward-text"></p>
+            <button id="reward-continue">Continue</button>
         </div>
 
         <div id="game-over-screen" class="hidden">
@@ -99,6 +106,11 @@
                 <div id="merchant-trade-cards"></div>
             </div>
             <button id="close-trading">Close Trading</button>
+        </div>
+
+        <div id="event-screen" class="hidden">
+            <p id="event-text"></p>
+            <button id="event-continue">Continue</button>
         </div>
 
         <div id="achievement-screen" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -791,3 +791,44 @@ body {
 #game-buttons button:hover {
     background: #2d3748;
 }
+
+/* Dungeon and Event Screens */
+#dungeon-screen, #event-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 560px;
+    gap: 20px;
+    text-align: center;
+}
+
+#room-options {
+    display: flex;
+    gap: 20px;
+}
+
+.room-button {
+    padding: 15px 30px;
+    background: #4a5568;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.room-button:hover {
+    background: #2d3748;
+}
+
+#gold-display {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    background: rgba(0,0,0,0.7);
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-weight: bold;
+    color: #ffd700;
+}


### PR DESCRIPTION
## Summary
- introduce a dungeon screen to choose between three random rooms
- show upcoming two rooms and player's gold
- add gold rewards after battles and events
- allow merchant room to open trading screen
- style new screens

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_685837018bf4832c80e5cb7c75817908