### PR TITLE
Add merchant packs, rest rooms, and room preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,10 @@
         <div id="dungeon-screen" class="hidden">
             <h2>Choose Your Room</h2>
             <div id="room-options"></div>
-            <div id="upcoming-rooms">Upcoming: <span id="upcoming-1"></span> -> <span id="upcoming-2"></span></div>
+            <div id="upcoming-rooms">
+                <div>Next Rooms: <span id="upcoming-set1"></span></div>
+                <div>Following Rooms: <span id="upcoming-set2"></span></div>
+            </div>
         </div>
 
         <div id="game-screen" class="hidden">
@@ -106,6 +109,23 @@
                 <div id="merchant-trade-cards"></div>
             </div>
             <button id="close-trading">Close Trading</button>
+        </div>
+
+        <div id="merchant-screen" class="hidden">
+            <h2>Merchant</h2>
+            <div id="pack-options"></div>
+            <button id="close-merchant">Close</button>
+        </div>
+
+        <div id="pack-screen" class="hidden">
+            <h2>Pack Contents</h2>
+            <div id="pack-cards"></div>
+            <button id="pack-continue">Continue</button>
+        </div>
+
+        <div id="rest-screen" class="hidden">
+            <p id="rest-text"></p>
+            <button id="rest-continue">Continue</button>
         </div>
 
         <div id="event-screen" class="hidden">


### PR DESCRIPTION
## Summary
- preview next sets of rooms when choosing a room
- implement new merchant screen with random card packs
- add pack opening screen and rest room logic
- diversify random events with traps, special card purchases and ambushes
- adjust room probabilities and queue length

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_68584e1b86cc832cbbb3a1084e4d348e