### PR TITLE
Improve merchant UI and global HP display

### DIFF
--- a/game.js
+++ b/game.js
@@ -67,6 +67,7 @@ class CardGame {
         this.battleLogElement = document.getElementById('battle-log');
 
         this.goldDisplay = document.getElementById('gold-display');
+        this.hpDisplay = document.getElementById('hp-display');
 
         this.roomOptionsElement = document.getElementById('room-options');
         this.upcoming1Element = document.getElementById('upcoming-set1');
@@ -143,6 +144,7 @@ class CardGame {
         this.tradingScreen.classList.add('hidden');
         this.achievementScreen.classList.add('hidden');
         this.goldDisplay.classList.add('hidden');
+        this.hpDisplay.classList.add('hidden');
     }
     
     // Show tutorial screen
@@ -162,6 +164,8 @@ class CardGame {
         
         this.titleScreen.classList.add('hidden');
         this.goldDisplay.classList.remove('hidden');
+        this.hpDisplay.classList.remove('hidden');
+        this.updateHpDisplay();
 
         this.initializeRoomQueue();
         this.showDungeonScreen();
@@ -332,6 +336,7 @@ class CardGame {
         
         this.playerEnergyElement.textContent = `Energy: ${this.playerEnergy}/${this.playerMaxEnergy}`;
         this.playerBlockElement.textContent = `Block: ${this.playerBlock}`;
+        this.updateHpDisplay();
     }
     
     // Update card piles display
@@ -564,6 +569,12 @@ class CardGame {
     updateGoldDisplay() {
         if (this.goldDisplay) {
             this.goldDisplay.textContent = `Gold: ${this.gold}`;
+        }
+    }
+
+    updateHpDisplay() {
+        if (this.hpDisplay) {
+            this.hpDisplay.textContent = `HP: ${this.playerHp}/${this.playerMaxHp}`;
         }
     }
     
@@ -868,7 +879,7 @@ class CardGame {
 
     // Show rest screen and heal player
     showRestScreen() {
-        const heal = Math.ceil(this.playerMaxHp * 0.3);
+        const heal = Math.ceil(this.playerHp * 0.3);
         this.playerHp = Math.min(this.playerHp + heal, this.playerMaxHp);
         this.updatePlayerStats();
         document.getElementById('rest-text').textContent = `You recovered ${heal} HP.`;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         </div>
 
         <div id="gold-display" class="hidden">Gold: 0</div>
+        <div id="hp-display" class="hidden">HP: 0/0</div>
 
         <div id="tutorial-screen" class="hidden">
             <h2>How to Play</h2>

--- a/styles.css
+++ b/styles.css
@@ -694,7 +694,7 @@ body {
 }
 
 /* Additional styles */
-#trading-screen, #achievement-screen {
+#trading-screen, #achievement-screen, #merchant-screen, #pack-screen {
     position: fixed;
     top: 50%;
     left: 50%;
@@ -831,4 +831,44 @@ body {
     border-radius: 5px;
     font-weight: bold;
     color: #ffd700;
+}
+
+#hp-display {
+    position: fixed;
+    top: 60px;
+    left: 20px;
+    background: rgba(0,0,0,0.7);
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-weight: bold;
+    color: #ff6b6b;
+}
+
+#pack-options {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.pack-button {
+    padding: 15px 30px;
+    background: #4a5568;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.pack-button:hover {
+    background: #2d3748;
+}
+
+#pack-cards {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 20px 0;
 }


### PR DESCRIPTION
## Summary
- show a persistent HP indicator like the gold counter
- center merchant pack buttons and pack cards
- style merchant elements
- heal 30% of current HP in rest rooms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859a1a27364832c923bba5c6e8973b0