### PR TITLE
Remove trading feature and add deck viewer

### DIFF
--- a/game.js
+++ b/game.js
@@ -44,7 +44,6 @@ class CardGame {
         this.eventScreen = document.getElementById('event-screen');
         this.rewardScreen = document.getElementById('reward-screen');
         this.gameOverScreen = document.getElementById('game-over-screen');
-        this.tradingScreen = document.getElementById('trading-screen');
         this.merchantScreen = document.getElementById('merchant-screen');
         this.packScreen = document.getElementById('pack-screen');
         this.restScreen = document.getElementById('rest-screen');
@@ -76,7 +75,8 @@ class CardGame {
         
         this.endTurnButton = document.getElementById('end-turn-button');
         this.rewardTextElement = document.getElementById('reward-text');
-        this.tradingButton = document.getElementById('trading-button');
+        this.deckButton = document.getElementById('deck-button');
+        this.deckScreen = document.getElementById('deck-screen');
         this.achievementsButton = document.getElementById('achievements-button');
         
         // Initialize buttons
@@ -96,14 +96,10 @@ class CardGame {
             }
         });
         document.getElementById('play-again').addEventListener('click', () => this.resetGame());
-        this.tradingButton.addEventListener('click', () => this.showTradingScreen());
+        this.deckButton.addEventListener('click', () => this.showDeckScreen());
         this.achievementsButton.addEventListener('click', () => this.showAchievementScreen());
-        document.getElementById('close-trading').addEventListener('click', () => {
-            document.getElementById('trading-screen').classList.add('hidden');
-            if (this.inMerchantRoom) {
-                this.inMerchantRoom = false;
-                this.showDungeonScreen();
-            }
+        document.getElementById('close-deck').addEventListener('click', () => {
+            this.deckScreen.classList.add('hidden');
         });
         document.getElementById('close-merchant').addEventListener('click', () => {
             this.merchantScreen.classList.add('hidden');
@@ -141,10 +137,12 @@ class CardGame {
         this.eventScreen.classList.add('hidden');
         this.rewardScreen.classList.add('hidden');
         this.gameOverScreen.classList.add('hidden');
-        this.tradingScreen.classList.add('hidden');
         this.achievementScreen.classList.add('hidden');
         this.goldDisplay.classList.add('hidden');
         this.hpDisplay.classList.add('hidden');
+        this.deckButton.classList.add('hidden');
+        this.deckScreen.classList.add('hidden');
+        document.getElementById('card-index-button').classList.remove('hidden');
     }
     
     // Show tutorial screen
@@ -165,6 +163,8 @@ class CardGame {
         this.titleScreen.classList.add('hidden');
         this.goldDisplay.classList.remove('hidden');
         this.hpDisplay.classList.remove('hidden');
+        this.deckButton.classList.remove('hidden');
+        document.getElementById('card-index-button').classList.add('hidden');
         this.updateHpDisplay();
 
         this.initializeRoomQueue();
@@ -568,13 +568,18 @@ class CardGame {
 
     updateGoldDisplay() {
         if (this.goldDisplay) {
-            this.goldDisplay.textContent = `Gold: ${this.gold}`;
+            const amt = this.goldDisplay.querySelector('#gold-amount');
+            if (amt) amt.textContent = this.gold;
         }
     }
 
     updateHpDisplay() {
         if (this.hpDisplay) {
-            this.hpDisplay.textContent = `HP: ${this.playerHp}/${this.playerMaxHp}`;
+            const txt = this.hpDisplay.querySelector('#hp-bar-text');
+            const bar = this.hpDisplay.querySelector('#hp-bar');
+            const percent = (this.playerHp / this.playerMaxHp) * 100;
+            if (txt) txt.textContent = `${this.playerHp}/${this.playerMaxHp}`;
+            if (bar) bar.style.width = `${percent}%`;
         }
     }
     
@@ -753,7 +758,7 @@ class CardGame {
     // Reset game for play again
     resetGame() {
         this.gameOverScreen.classList.add('hidden');
-        this.titleScreen.classList.remove('hidden');
+        this.showTitleScreen();
     }
     
     // Add message to battle log
@@ -875,6 +880,17 @@ class CardGame {
         });
         this.merchantScreen.classList.add('hidden');
         this.packScreen.classList.remove('hidden');
+    }
+
+    // Show deck contents
+    showDeckScreen() {
+        const container = document.getElementById('deck-cards');
+        container.innerHTML = '';
+        this.deck.forEach(card => {
+            const el = card.createCardElement();
+            container.appendChild(el);
+        });
+        this.deckScreen.classList.remove('hidden');
     }
 
     // Show rest screen and heal player

--- a/index.html
+++ b/index.html
@@ -11,10 +11,21 @@
             <h1>Card Battler: The Sequel</h1>
             <button id="start-game">Start Game</button>
             <button id="how-to-play">How to Play</button>
+            <button id="achievements-button">Achievements</button>
         </div>
 
-        <div id="gold-display" class="hidden">Gold: 0</div>
-        <div id="hp-display" class="hidden">HP: 0/0</div>
+        <div id="gold-display" class="hidden">
+            <img id="gold-icon" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KPHJlY3QgeD0iMiIgeT0iOCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjE0IiBmaWxsPSIjYjU2NTFkIiBzdHJva2U9IiM1YTJkMGMiIHN0cm9rZS13aWR0aD0iMiIvPgo8cmVjdCB4PSIyIiB5PSI0IiB3aWR0aD0iMjAiIGhlaWdodD0iOCIgc3Ryb2tlPSIjNWEyZDBjIiBmaWxsPSIjZDE3YjIyIiBzdHJva2Utd2lkdGg9IjIiLz4KPGxpbmUgeDE9IjIiIHkxPSIxMCIgeDI9IjIyIiB5Mj0iMTAiIHN0cm9rZT0iIzVhMmQwYyIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPg==" alt="Chest">
+            <span id="gold-amount">0</span>
+        </div>
+        <div id="hp-display" class="hidden">
+            <img id="hp-icon" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAyOSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjIyIj4KPHBhdGggZD0iTTIzLjYgMGMtMy4xIDAtNS44IDEuOC03LjYgNC41QzE0LjIgMS44IDExLjUgMCA4LjQgMCAzLjggMCAwIDMuNiAwIDguMWMwIDkuMSAxNiAyMC45IDE2IDIwLjlTMzIgMTcuMiAzMiA4LjFDMzIgMy42IDI4LjIgMCAyMy42IDB6IiBmaWxsPSIjZTYzOTQ2Ii8+Cjwvc3ZnPg==" alt="Heart">
+            <div id="hp-bar-container">
+                <div id="hp-bar-text">0/0</div>
+                <div id="hp-bar"></div>
+            </div>
+        </div>
+        <button id="deck-button" class="hidden">Deck</button>
 
         <div id="tutorial-screen" class="hidden">
             <h2>How to Play</h2>
@@ -84,10 +95,7 @@
                 </div>
             </div>
 
-            <div id="game-buttons">
-                <button id="trading-button">Trading</button>
-                <button id="achievements-button">Achievements</button>
-            </div>
+            <div id="game-buttons"></div>
         </div>
 
         <div id="reward-screen" class="hidden">
@@ -103,14 +111,6 @@
             <button id="play-again">Play Again</button>
         </div>
 
-        <div id="trading-screen" class="hidden">
-            <h2>Card Trading</h2>
-            <div id="trading-options">
-                <div id="player-trade-cards"></div>
-                <div id="merchant-trade-cards"></div>
-            </div>
-            <button id="close-trading">Close Trading</button>
-        </div>
 
         <div id="merchant-screen" class="hidden">
             <h2>Merchant</h2>
@@ -122,6 +122,12 @@
             <h2>Pack Contents</h2>
             <div id="pack-cards"></div>
             <button id="pack-continue">Continue</button>
+        </div>
+
+        <div id="deck-screen" class="hidden">
+            <h2>Your Deck</h2>
+            <div id="deck-cards"></div>
+            <button id="close-deck">Close</button>
         </div>
 
         <div id="rest-screen" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -694,7 +694,7 @@ body {
 }
 
 /* Additional styles */
-#trading-screen, #achievement-screen, #merchant-screen, #pack-screen {
+#trading-screen, #achievement-screen, #merchant-screen, #pack-screen, #deck-screen {
     position: fixed;
     top: 50%;
     left: 50%;
@@ -827,10 +827,18 @@ body {
     top: 20px;
     left: 20px;
     background: rgba(0,0,0,0.7);
-    padding: 10px 20px;
+    padding: 8px 12px;
     border-radius: 5px;
-    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 5px;
     color: #ffd700;
+    font-weight: bold;
+}
+
+#gold-display img {
+    width: 24px;
+    height: 24px;
 }
 
 #hp-display {
@@ -838,10 +846,62 @@ body {
     top: 60px;
     left: 20px;
     background: rgba(0,0,0,0.7);
-    padding: 10px 20px;
+    padding: 8px 12px;
     border-radius: 5px;
-    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 5px;
     color: #ff6b6b;
+    font-weight: bold;
+}
+
+#hp-display img {
+    width: 24px;
+    height: 22px;
+}
+
+#hp-bar-container {
+    position: relative;
+    width: 120px;
+    height: 20px;
+    background-color: #2d3748;
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+#hp-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background-color: #ff6b6b;
+    width: 100%;
+    transition: width 0.5s;
+}
+
+#hp-bar-text {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    text-align: center;
+    font-size: 0.9rem;
+    line-height: 20px;
+}
+
+#deck-button {
+    position: fixed;
+    top: 100px;
+    left: 20px;
+    padding: 8px 16px;
+    background: #4a5568;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+#deck-button:hover {
+    background: #2d3748;
 }
 
 #pack-options {
@@ -866,6 +926,14 @@ body {
 }
 
 #pack-cards {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 20px 0;
+}
+
+#deck-cards {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- remove trading button and screen
- add achievements button to title screen
- hide card index button during gameplay and show new deck viewer button
- display gold as chest icon and HP with heart/bar
- style deck screen and HUD elements

## Testing
- `node -c game.js`
- `node -c cards.js`
- `node -c enemies.js`
- `node -c achievements.js`

------
https://chatgpt.com/codex/tasks/task_e_685a8553e050832ca6ea750597f2d084