### PR TITLE
Improve deck view and events

### DIFF
--- a/game.js
+++ b/game.js
@@ -29,6 +29,8 @@ class CardGame {
         this.achievements = [...achievements];
         this.inMerchantRoom = false;
         this.pendingAmbush = false;
+        this.eventCardForSale = null;
+        this.eventCardCost = 0;
         
         this.initializeGame();
     }
@@ -95,11 +97,32 @@ class CardGame {
                 this.showDungeonScreen();
             }
         });
+        document.getElementById('event-buy').addEventListener('click', () => {
+            if (this.gold >= this.eventCardCost && this.eventCardForSale) {
+                this.gold -= this.eventCardCost;
+                this.updateGoldDisplay();
+                this.addCardToDeck(this.eventCardForSale);
+            }
+            this.hideEventButtons();
+            this.eventScreen.classList.add('hidden');
+            this.showDungeonScreen();
+        });
+        document.getElementById('event-skip').addEventListener('click', () => {
+            this.hideEventButtons();
+            this.eventScreen.classList.add('hidden');
+            this.showDungeonScreen();
+        });
         document.getElementById('play-again').addEventListener('click', () => this.resetGame());
         this.deckButton.addEventListener('click', () => this.showDeckScreen());
         this.achievementsButton.addEventListener('click', () => this.showAchievementScreen());
+        const deckBackdrop = document.querySelector('.card-backdrop');
         document.getElementById('close-deck').addEventListener('click', () => {
             this.deckScreen.classList.add('hidden');
+            deckBackdrop.classList.remove('active');
+        });
+        deckBackdrop.addEventListener('click', () => {
+            this.deckScreen.classList.add('hidden');
+            deckBackdrop.classList.remove('active');
         });
         document.getElementById('close-merchant').addEventListener('click', () => {
             this.merchantScreen.classList.add('hidden');
@@ -109,7 +132,9 @@ class CardGame {
             }
         });
         document.getElementById('pack-continue').addEventListener('click', () => {
+            const deckBackdrop = document.querySelector('.card-backdrop');
             this.packScreen.classList.add('hidden');
+            deckBackdrop.classList.remove('active');
             if (this.inMerchantRoom) {
                 this.showMerchantScreen();
             } else {
@@ -296,20 +321,32 @@ class CardGame {
             this.dealDamageToPlayer(damage);
             this.eventTextElement.textContent = `A trap deals ${damage} damage!`;
         } else if (roll < 0.9) {
-            const cost = 20;
-            const card = getRandomCard();
-            if (this.gold >= cost) {
-                this.gold -= cost;
-                this.updateGoldDisplay();
-                this.addCardToDeck(card);
-                this.eventTextElement.textContent = `You pay ${cost} gold and receive ${card.name}!`;
+            this.eventCardCost = 20;
+            this.eventCardForSale = getRandomCard();
+            if (this.gold >= this.eventCardCost) {
+                this.eventTextElement.textContent = `A dealer offers ${this.eventCardForSale.name} for ${this.eventCardCost} gold.`;
+                this.showEventButtons();
             } else {
-                this.eventTextElement.textContent = `A dealer offers ${card.name} for ${cost} gold, but you can't afford it.`;
+                this.eventTextElement.textContent = `A dealer offers ${this.eventCardForSale.name} for ${this.eventCardCost} gold, but you can't afford it.`;
             }
         } else {
             this.pendingAmbush = true;
             this.eventTextElement.textContent = 'You are ambushed by an enemy!';
         }
+    }
+
+    showEventButtons() {
+        document.getElementById('event-continue').classList.add('hidden');
+        document.getElementById('event-buy').classList.remove('hidden');
+        document.getElementById('event-skip').classList.remove('hidden');
+    }
+
+    hideEventButtons() {
+        document.getElementById('event-continue').classList.remove('hidden');
+        document.getElementById('event-buy').classList.add('hidden');
+        document.getElementById('event-skip').classList.add('hidden');
+        this.eventCardForSale = null;
+        this.eventCardCost = 0;
     }
     
     // Update enemy health display
@@ -878,8 +915,9 @@ class CardGame {
             packCardsDiv.appendChild(el);
             this.addCardToDeck(card);
         });
-        this.merchantScreen.classList.add('hidden');
+        const deckBackdrop = document.querySelector('.card-backdrop');
         this.packScreen.classList.remove('hidden');
+        deckBackdrop.classList.add('active');
     }
 
     // Show deck contents
@@ -890,7 +928,9 @@ class CardGame {
             const el = card.createCardElement();
             container.appendChild(el);
         });
+        const deckBackdrop = document.querySelector('.card-backdrop');
         this.deckScreen.classList.remove('hidden');
+        deckBackdrop.classList.add('active');
     }
 
     // Show rest screen and heal player

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         <div id="merchant-screen" class="hidden">
             <h2>Merchant</h2>
             <div id="pack-options"></div>
-            <button id="close-merchant">Close</button>
+            <button id="close-merchant">Continue</button>
         </div>
 
         <div id="pack-screen" class="hidden">
@@ -125,9 +125,9 @@
         </div>
 
         <div id="deck-screen" class="hidden">
+            <button id="close-deck" class="close-button">&times;</button>
             <h2>Your Deck</h2>
             <div id="deck-cards"></div>
-            <button id="close-deck">Close</button>
         </div>
 
         <div id="rest-screen" class="hidden">
@@ -137,7 +137,11 @@
 
         <div id="event-screen" class="hidden">
             <p id="event-text"></p>
-            <button id="event-continue">Continue</button>
+            <div id="event-buttons">
+                <button id="event-buy" class="hidden">Buy</button>
+                <button id="event-skip" class="hidden">Skip</button>
+                <button id="event-continue">Continue</button>
+            </div>
         </div>
 
         <div id="achievement-screen" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -654,6 +654,18 @@ body {
     padding: 10px;
 }
 
+.close-button {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 24px;
+    color: white;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 10px;
+}
+
 #card-index-content {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -707,6 +719,10 @@ body {
     padding: 30px;
     border-radius: 20px;
     z-index: 100;
+}
+
+#deck-screen {
+    overflow-y: auto;
 }
 
 #trading-options {
@@ -940,4 +956,40 @@ body {
     flex-wrap: wrap;
     gap: 10px;
     margin: 20px 0;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+#rest-screen button, #merchant-screen button, #pack-screen button, #event-buttons button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 10px auto;
+    padding: 15px 30px;
+    background: #4a5568;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+#rest-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 560px;
+    gap: 20px;
+    text-align: center;
+}
+
+#merchant-screen button:hover, #pack-screen button:hover, #event-buttons button:hover {
+    background: #2d3748;
+}
+
+#event-buttons {
+    display: flex;
+    gap: 20px;
+    justify-content: center;
+    margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- enable scrolling deck view with a backdrop and close icon
- style and center rest and merchant screens
- allow card purchase choice in events
- keep merchant open for multiple pack purchases

## Testing
- `node --check game.js`
- `node --check cards.js`
- `node --check enemies.js`
- `node --check achievements.js`


------
https://chatgpt.com/codex/tasks/task_e_685a8b00efd8832c8a3ed6b20141ffa1