### PR TITLE
Add gold change animations

### DIFF
--- a/game.js
+++ b/game.js
@@ -99,8 +99,7 @@ class CardGame {
         });
         document.getElementById('event-buy').addEventListener('click', () => {
             if (this.gold >= this.eventCardCost && this.eventCardForSale) {
-                this.gold -= this.eventCardCost;
-                this.updateGoldDisplay();
+                this.addGold(-this.eventCardCost);
                 this.addCardToDeck(this.eventCardForSale);
             }
             this.hideEventButtons();
@@ -604,10 +603,16 @@ class CardGame {
         this.updatePlayerStats();
     }
 
-    // Add gold to player
+    // Add or subtract gold with animation
     addGold(amount) {
         this.gold += amount;
         this.updateGoldDisplay();
+
+        if (this.goldDisplay) {
+            const cls = amount >= 0 ? 'gold-text' : 'gold-loss-text';
+            const prefix = amount >= 0 ? '+' : '';
+            this.createFloatingText(`${prefix}${amount}`, cls, this.goldDisplay);
+        }
     }
 
     updateGoldDisplay() {
@@ -910,8 +915,7 @@ class CardGame {
     // Purchase a pack of cards
     purchasePack(pack) {
         if (this.gold < pack.price) return;
-        this.gold -= pack.price;
-        this.updateGoldDisplay();
+        this.addGold(-pack.price);
         const cards = [];
         for (let i = 0; i < pack.size; i++) {
             cards.push(getRandomCard());

--- a/styles.css
+++ b/styles.css
@@ -598,6 +598,23 @@ body {
     100% { transform: translateY(-30px); opacity: 0; }
 }
 
+.gold-text,
+.gold-loss-text {
+    position: absolute;
+    font-size: 1.5rem;
+    font-weight: bold;
+    animation: gold-float 1s forwards;
+    z-index: 10;
+}
+
+.gold-text { color: #ffd700; }
+.gold-loss-text { color: #ff4444; }
+
+@keyframes gold-float {
+    0% { transform: translateY(0); opacity: 1; }
+    100% { transform: translateY(-30px); opacity: 0; }
+}
+
 .status-icon {
     width: 24px;
     height: 24px;


### PR DESCRIPTION
## Summary
- animate gold gain/loss with floating text
- use the new function when purchasing cards or buying event cards
- style the gold gain and loss text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a9d0ae2cc832c9803ae674b794c39