### PR TITLE
Add draw & discard pile screens

### DIFF
--- a/game.js
+++ b/game.js
@@ -79,6 +79,8 @@ class CardGame {
         this.rewardTextElement = document.getElementById('reward-text');
         this.deckButton = document.getElementById('deck-button');
         this.deckScreen = document.getElementById('deck-screen');
+        this.drawPileScreen = document.getElementById('draw-pile-screen');
+        this.discardPileScreen = document.getElementById('discard-pile-screen');
         this.achievementsButton = document.getElementById('achievements-button');
         
         // Initialize buttons
@@ -113,14 +115,26 @@ class CardGame {
         });
         document.getElementById('play-again').addEventListener('click', () => this.resetGame());
         this.deckButton.addEventListener('click', () => this.showDeckScreen());
+        this.deckPile.addEventListener('click', () => this.showDrawPileScreen());
+        this.discardPileElement.addEventListener('click', () => this.showDiscardPileScreen());
         this.achievementsButton.addEventListener('click', () => this.showAchievementScreen());
         const deckBackdrop = document.querySelector('.card-backdrop');
         document.getElementById('close-deck').addEventListener('click', () => {
             this.deckScreen.classList.add('hidden');
             deckBackdrop.classList.remove('active');
         });
+        document.getElementById('close-draw-pile').addEventListener('click', () => {
+            this.drawPileScreen.classList.add('hidden');
+            deckBackdrop.classList.remove('active');
+        });
+        document.getElementById('close-discard-pile').addEventListener('click', () => {
+            this.discardPileScreen.classList.add('hidden');
+            deckBackdrop.classList.remove('active');
+        });
         deckBackdrop.addEventListener('click', () => {
             this.deckScreen.classList.add('hidden');
+            this.drawPileScreen.classList.add('hidden');
+            this.discardPileScreen.classList.add('hidden');
             deckBackdrop.classList.remove('active');
         });
         document.getElementById('close-merchant').addEventListener('click', () => {
@@ -166,6 +180,8 @@ class CardGame {
         this.hpDisplay.classList.add('hidden');
         this.deckButton.classList.add('hidden');
         this.deckScreen.classList.add('hidden');
+        this.drawPileScreen.classList.add('hidden');
+        this.discardPileScreen.classList.add('hidden');
         document.getElementById('card-index-button').classList.remove('hidden');
     }
     
@@ -942,6 +958,32 @@ class CardGame {
         });
         const deckBackdrop = document.querySelector('.card-backdrop');
         this.deckScreen.classList.remove('hidden');
+        deckBackdrop.classList.add('active');
+    }
+
+    // Show draw pile contents
+    showDrawPileScreen() {
+        const container = document.getElementById('draw-pile-cards');
+        container.innerHTML = '';
+        this.drawPile.forEach(card => {
+            const el = card.createCardElement();
+            container.appendChild(el);
+        });
+        const deckBackdrop = document.querySelector('.card-backdrop');
+        this.drawPileScreen.classList.remove('hidden');
+        deckBackdrop.classList.add('active');
+    }
+
+    // Show discard pile contents
+    showDiscardPileScreen() {
+        const container = document.getElementById('discard-pile-cards');
+        container.innerHTML = '';
+        this.discardPile.forEach(card => {
+            const el = card.createCardElement();
+            container.appendChild(el);
+        });
+        const deckBackdrop = document.querySelector('.card-backdrop');
+        this.discardPileScreen.classList.remove('hidden');
         deckBackdrop.classList.add('active');
     }
 

--- a/index.html
+++ b/index.html
@@ -130,6 +130,18 @@
             <div id="deck-cards"></div>
         </div>
 
+        <div id="draw-pile-screen" class="hidden">
+            <button id="close-draw-pile" class="close-button">&times;</button>
+            <h2>Pioche</h2>
+            <div id="draw-pile-cards"></div>
+        </div>
+
+        <div id="discard-pile-screen" class="hidden">
+            <button id="close-discard-pile" class="close-button">&times;</button>
+            <h2>Défausse</h2>
+            <div id="discard-pile-cards"></div>
+        </div>
+
         <div id="rest-screen" class="hidden">
             <p id="rest-text"></p>
             <button id="rest-continue">Continue</button>

--- a/styles.css
+++ b/styles.css
@@ -260,13 +260,14 @@ body {
 .card-pile {
     width: 80px;
     height: 120px;
-    background-color: rgba(0, 0, 0, 0.5);
+    background: url('images/back_card.png') no-repeat center/cover;
     border: 2px solid #4a5568;
     border-radius: 5px;
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
+    cursor: pointer;
 }
 
 .pile-count {
@@ -730,7 +731,8 @@ body {
 }
 
 /* Additional styles */
-#trading-screen, #achievement-screen, #pack-screen, #deck-screen {
+#trading-screen, #achievement-screen, #pack-screen, #deck-screen,
+#draw-pile-screen, #discard-pile-screen {
     position: fixed;
     top: 50%;
     left: 50%;
@@ -760,7 +762,9 @@ body {
     z-index: 100;
 }
 
-#deck-screen {
+#deck-screen,
+#draw-pile-screen,
+#discard-pile-screen {
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- add draw/discard pile viewing screens
- show piles when clicking the deck or discard
- style piles with card back image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aa4d8532c832caf6647049315afaa