### PR TITLE
Fix card selection bug and improve pile views

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -14,7 +14,7 @@ class Card {
     }
 
     // Create HTML element for the card
-    createCardElement() {
+    createCardElement(interactive = true) {
         const cardElement = document.createElement('div');
         cardElement.className = `card ${this.type} ${this.rarity}`;
         cardElement.dataset.cardId = this.id;
@@ -41,13 +41,15 @@ class Card {
         cardElement.appendChild(descriptionElement);
         cardElement.appendChild(typeElement);
 
-        // Add event listener for playing the card
-        cardElement.addEventListener('click', () => {
-            // Check if the card is playable (enough energy and valid target)
-            if (game.canPlayCard(this)) {
-                game.playCard(this);
-            }
-        });
+        if (interactive) {
+            // Add event listener for playing the card
+            cardElement.addEventListener('click', () => {
+                // Check if the card is playable (enough energy and valid target)
+                if (game.canPlayCard(this)) {
+                    game.playCard(this);
+                }
+            });
+        }
 
         return cardElement;
     }
@@ -317,7 +319,7 @@ function initializeCardIndex() {
         // Clear and populate card index
         cardIndexContent.innerHTML = '';
         cardCollection.forEach(card => {
-            const cardElement = card.createCardElement();
+            const cardElement = card.createCardElement(false);
             cardIndexContent.appendChild(cardElement);
         });
     });

--- a/game.js
+++ b/game.js
@@ -868,7 +868,7 @@ class CardGame {
         
         playerTradeCards.innerHTML = '';
         this.deck.forEach(card => {
-            const cardElement = card.createCardElement();
+            const cardElement = card.createCardElement(false);
             cardElement.addEventListener('click', () => this.tradeCard(card));
             playerTradeCards.appendChild(cardElement);
         });
@@ -876,7 +876,7 @@ class CardGame {
         merchantTradeCards.innerHTML = '';
         const tradeOptions = getRandomTradeOptions();
         tradeOptions.forEach(card => {
-            const cardElement = card.createCardElement();
+            const cardElement = card.createCardElement(false);
             merchantTradeCards.appendChild(cardElement);
         });
     }
@@ -939,7 +939,7 @@ class CardGame {
         const packCardsDiv = document.getElementById('pack-cards');
         packCardsDiv.innerHTML = '';
         cards.forEach(card => {
-            const el = card.createCardElement();
+            const el = card.createCardElement(false);
             packCardsDiv.appendChild(el);
             this.addCardToDeck(card);
         });
@@ -953,7 +953,7 @@ class CardGame {
         const container = document.getElementById('deck-cards');
         container.innerHTML = '';
         this.deck.forEach(card => {
-            const el = card.createCardElement();
+            const el = card.createCardElement(false);
             container.appendChild(el);
         });
         const deckBackdrop = document.querySelector('.card-backdrop');
@@ -966,7 +966,7 @@ class CardGame {
         const container = document.getElementById('draw-pile-cards');
         container.innerHTML = '';
         this.drawPile.forEach(card => {
-            const el = card.createCardElement();
+            const el = card.createCardElement(false);
             container.appendChild(el);
         });
         const deckBackdrop = document.querySelector('.card-backdrop');
@@ -979,7 +979,7 @@ class CardGame {
         const container = document.getElementById('discard-pile-cards');
         container.innerHTML = '';
         this.discardPile.forEach(card => {
-            const el = card.createCardElement();
+            const el = card.createCardElement(false);
             container.appendChild(el);
         });
         const deckBackdrop = document.querySelector('.card-backdrop');

--- a/styles.css
+++ b/styles.css
@@ -1009,7 +1009,9 @@ body {
     margin: 20px 0;
 }
 
-#deck-cards {
+#deck-cards,
+#draw-pile-cards,
+#discard-pile-cards {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- prevent playing cards from deck, draw pile, discard pile and card index by making preview cards non interactive
- apply same grid layout used for deck preview to draw and discard pile screens

## Testing
- `node -v`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_685aae781224832cb6afd1d3d97aaa0c