### PR TITLE
Add deck management screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,8 +126,16 @@
 
         <div id="deck-screen" class="hidden">
             <button id="close-deck" class="close-button">&times;</button>
-            <h2>Your Deck</h2>
-            <div id="deck-cards"></div>
+            <div id="deck-management">
+                <div class="deck-section">
+                    <h3>Deck (<span id="deck-count">0/20</span>)</h3>
+                    <div id="deck-cards"></div>
+                </div>
+                <div class="deck-section">
+                    <h3>Collection</h3>
+                    <div id="collection-cards"></div>
+                </div>
+            </div>
         </div>
 
         <div id="draw-pile-screen" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -768,6 +768,27 @@ body {
     overflow-y: auto;
 }
 
+#deck-management {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+}
+
+.deck-section {
+    width: 48%;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 20px;
+    border-radius: 10px;
+    overflow-y: auto;
+    max-height: 70vh;
+}
+
+.deck-section h3 {
+    text-align: center;
+    color: #fff;
+    margin-bottom: 10px;
+}
+
 #trading-options {
     display: flex;
     justify-content: space-between;
@@ -1010,6 +1031,7 @@ body {
 }
 
 #deck-cards,
+#collection-cards,
 #draw-pile-cards,
 #discard-pile-cards {
     display: flex;


### PR DESCRIPTION
## Summary
- show a new deck management UI where the deck and the player's full collection are displayed
- allow adding/removing cards by clicking cards in the deck screen
- enforce deck limits (10-20 cards) and show current count
- store all owned cards separately from the active deck
- style the new deck management screen

## Testing
- `node -e "require('./game.js');"` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ab28df600832c926dca6b5b93b0a2