### PR TITLE
Move log to sidebar and hide deck button in battle

### DIFF
--- a/game.js
+++ b/game.js
@@ -183,6 +183,7 @@ class CardGame {
         this.goldDisplay.classList.add('hidden');
         this.hpDisplay.classList.add('hidden');
         this.deckButton.classList.add('hidden');
+        this.battleLogElement.classList.add('hidden');
         this.deckScreen.classList.add('hidden');
         this.drawPileScreen.classList.add('hidden');
         this.discardPileScreen.classList.add('hidden');
@@ -241,6 +242,8 @@ class CardGame {
         this.rewardScreen.classList.add('hidden');
         this.eventScreen.classList.add('hidden');
         this.dungeonScreen.classList.remove('hidden');
+        this.battleLogElement.classList.add('hidden');
+        this.deckButton.classList.remove('hidden');
         this.dungeonScreen.style.background = "url('images/Choose_room.png') no-repeat center / cover";
 
         this.roomOptionsElement.innerHTML = '';
@@ -327,6 +330,8 @@ class CardGame {
         this.updateCardPiles();
         this.clearBattleLog();
         this.addToBattleLog(`Battle with ${this.currentEnemy.name} begins!`);
+        this.battleLogElement.classList.remove('hidden');
+        this.deckButton.classList.add('hidden');
         
         this.battleActive = true;
     }
@@ -334,6 +339,8 @@ class CardGame {
     // Start a random event
     startRandomEvent() {
         this.eventScreen.classList.remove('hidden');
+        this.battleLogElement.classList.add('hidden');
+        this.deckButton.classList.remove('hidden');
         this.pendingAmbush = false;
         const roll = Math.random();
         if (roll < 0.4) {
@@ -808,6 +815,8 @@ class CardGame {
     showRewardScreen() {
         this.gameScreen.classList.add('hidden');
         this.rewardScreen.classList.remove('hidden');
+        this.battleLogElement.classList.add('hidden');
+        this.deckButton.classList.remove('hidden');
         const goldReward = 20 + Math.floor(Math.random() * 11); // 20-30 gold
         this.addGold(goldReward);
         this.rewardTextElement.textContent = `You gained ${goldReward} gold!`;
@@ -834,6 +843,8 @@ class CardGame {
     showGameOverScreen() {
         this.gameScreen.classList.add('hidden');
         this.gameOverScreen.classList.remove('hidden');
+        this.battleLogElement.classList.add('hidden');
+        this.deckButton.classList.remove('hidden');
         
         document.getElementById('final-score').textContent = `You defeated ${this.enemiesDefeated} enemies.`;
     }
@@ -929,6 +940,8 @@ class CardGame {
     showMerchantScreen(fromDungeon = false) {
         this.inMerchantRoom = fromDungeon;
         this.merchantScreen.classList.remove('hidden');
+        this.battleLogElement.classList.add('hidden');
+        this.deckButton.classList.remove('hidden');
         this.merchantScreen.style.background = "url('images/rooms/room_merchant.png') no-repeat center / cover";
         this.updatePackOptions();
     }
@@ -1044,6 +1057,8 @@ class CardGame {
         this.updatePlayerStats();
         document.getElementById('rest-text').textContent = `You recovered ${heal} HP.`;
         this.restScreen.classList.remove('hidden');
+        this.battleLogElement.classList.add('hidden');
+        this.deckButton.classList.remove('hidden');
         this.restScreen.style.background = "url('images/rooms/room_rest.png') no-repeat center / cover";
     }
     

--- a/index.html
+++ b/index.html
@@ -65,7 +65,6 @@
                     </div>
                 </div>
 
-                <div id="battle-log"></div>
 
                 <div id="player-section">
                     <div id="player-stats">
@@ -97,6 +96,8 @@
 
             <div id="game-buttons"></div>
         </div>
+
+        <div id="battle-log" class="hidden"></div>
 
         <div id="reward-screen" class="hidden">
             <h2>Victory!</h2>

--- a/styles.css
+++ b/styles.css
@@ -197,12 +197,17 @@ body {
 }
 
 #battle-log {
-    height: 10%;
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 200px;
+    height: 100%;
     overflow-y: auto;
     padding: 10px;
-    background-color: rgba(0, 0, 0, 0.5);
-    border-radius: 5px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 5px 0 0 5px;
     font-size: 0.9rem;
+    z-index: 1000;
 }
 
 #player-section {


### PR DESCRIPTION
## Summary
- move battle log container outside of the game screen
- position log as a fixed sidebar on the right
- hide battle log and show deck button when not in battle
- hide deck button and show the battle log when a fight starts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ab6b8d4b0832c8085fb177caf620e