### PR TITLE
Add flip reveal for merchant packs

### DIFF
--- a/game.js
+++ b/game.js
@@ -1025,13 +1025,46 @@ class CardGame {
         for (let i = 0; i < pack.size; i++) {
             cards.push(getRandomCard());
         }
+
         const packCardsDiv = document.getElementById('pack-cards');
         packCardsDiv.innerHTML = '';
+
         cards.forEach(card => {
-            const el = card.createCardElement(false);
-            packCardsDiv.appendChild(el);
+            const isNew = !this.collection.some(c => c.id === card.id);
             this.addCardToDeck(card);
+
+            const flipCard = document.createElement('div');
+            flipCard.className = 'flip-card';
+
+            const inner = document.createElement('div');
+            inner.className = 'flip-card-inner';
+
+            const back = document.createElement('div');
+            back.className = 'flip-card-back';
+
+            const frontWrapper = document.createElement('div');
+            frontWrapper.className = 'flip-card-front';
+            const frontCard = card.createCardElement(false);
+            frontCard.style.pointerEvents = 'none';
+            frontWrapper.appendChild(frontCard);
+
+            inner.appendChild(back);
+            inner.appendChild(frontWrapper);
+            flipCard.appendChild(inner);
+
+            const label = document.createElement('div');
+            label.className = 'card-new-label';
+            flipCard.appendChild(label);
+
+            flipCard.addEventListener('click', () => {
+                if (flipCard.classList.contains('flipped')) return;
+                flipCard.classList.add('flipped');
+                label.textContent = isNew ? 'New Card!' : 'Duplicate';
+            });
+
+            packCardsDiv.appendChild(flipCard);
         });
+
         this.updateDeckCount();
         const deckBackdrop = document.querySelector('.card-backdrop');
         this.packScreen.classList.remove('hidden');

--- a/styles.css
+++ b/styles.css
@@ -1053,6 +1053,50 @@ body {
     margin: 20px 0;
 }
 
+.flip-card {
+    width: 140px;
+    height: 200px;
+    perspective: 1000px;
+}
+
+.flip-card-inner {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+    cursor: pointer;
+}
+
+.flip-card.flipped .flip-card-inner {
+    transform: rotateY(180deg);
+}
+
+.flip-card-front, .flip-card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border-radius: 8px;
+}
+
+.flip-card-front {
+    transform: rotateY(180deg);
+    pointer-events: none;
+}
+
+.flip-card-back {
+    background: url('images/back_card.png') no-repeat center/cover;
+}
+
+.card-new-label {
+    text-align: center;
+    margin-top: 5px;
+    color: #ffd700;
+    font-weight: bold;
+    min-height: 1em;
+}
+
 #deck-cards,
 #collection-cards,
 #draw-pile-cards,


### PR DESCRIPTION
## Summary
- update `purchasePack` to show cards face down and flip on click
- mark newly acquired cards after reveal
- style pack cards with flip animation

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6863bf4f15c0832c98f1a8d3f7849703