### PR TITLE
Improve merchant pack card interactions

### DIFF
--- a/game.js
+++ b/game.js
@@ -1045,7 +1045,6 @@ class CardGame {
             const frontWrapper = document.createElement('div');
             frontWrapper.className = 'flip-card-front';
             const frontCard = card.createCardElement(false);
-            frontCard.style.pointerEvents = 'none';
             frontWrapper.appendChild(frontCard);
 
             inner.appendChild(back);
@@ -1059,7 +1058,10 @@ class CardGame {
             flipCard.addEventListener('click', () => {
                 if (flipCard.classList.contains('flipped')) return;
                 flipCard.classList.add('flipped');
-                label.textContent = isNew ? 'New Card!' : 'Duplicate';
+                label.textContent = isNew ? 'New Card!' : '';
+                if (isNew) {
+                    frontCard.classList.add('card-glow');
+                }
             });
 
             packCardsDiv.appendChild(flipCard);

--- a/styles.css
+++ b/styles.css
@@ -1082,7 +1082,6 @@ body {
 
 .flip-card-front {
     transform: rotateY(180deg);
-    pointer-events: none;
 }
 
 .flip-card-back {
@@ -1095,6 +1094,15 @@ body {
     color: #ffd700;
     font-weight: bold;
     min-height: 1em;
+}
+
+@keyframes card-glow {
+    0% { box-shadow: 0 0 10px 5px rgba(255, 255, 255, 0.8); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
+}
+
+.card-glow {
+    animation: card-glow 0.8s ease-out forwards;
 }
 
 #deck-cards,


### PR DESCRIPTION
## Summary
- make merchant pack cards zoom on hover by enabling pointer events
- remove duplicate label and add glow effect for new cards

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863c2027684832c9a01aff26ef50718