### PR TITLE
Add card pack audio and hover layering

### DIFF
--- a/game.js
+++ b/game.js
@@ -744,7 +744,8 @@ class CardGame {
             block: new Audio('audio/GainDefense_RR1_v3.ogg'),
             gainGold: new Audio('audio/Gold_RR1_v3.ogg'),
             spendGold: new Audio('audio/CashRegister.ogg'),
-            chest: new Audio('audio/ChestOpen_v2.ogg')
+            chest: new Audio('audio/ChestOpen_v2.ogg'),
+            cardDeal: new Audio('audio/STS_SFX_CardDeal8_v1.ogg')
         };
     }
 
@@ -1096,6 +1097,7 @@ class CardGame {
 
             flipCard.addEventListener('click', () => {
                 if (flipCard.classList.contains('flipped')) return;
+                this.playSound('cardDeal');
                 flipCard.classList.add('flipped');
                 label.textContent = isNew ? 'New Card!' : '';
                 if (isNew) {

--- a/styles.css
+++ b/styles.css
@@ -310,7 +310,8 @@ body {
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
     position: relative;
     overflow: hidden;
-    
+    z-index: 1;
+
 }
 
 .card::before {
@@ -429,7 +430,7 @@ body {
 .card:hover {
     transform: translateY(-10px) scale(1.7);
     box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
-    z-index: 10; 
+    z-index: 50;
 }
 /*
 .card.common {
@@ -1057,6 +1058,12 @@ body {
     width: 140px;
     height: 200px;
     perspective: 1000px;
+    position: relative;
+    z-index: 1;
+}
+
+.flip-card:hover {
+    z-index: 50;
 }
 
 .flip-card-inner {


### PR DESCRIPTION
## Summary
- play a card dealing sound when revealing cards from packs
- add new audio resource to game sounds
- ensure cards and flip-cards appear above others when hovered

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68663e4799f4832cbecddb3b47d9f7bd