### PR TITLE
Bugfix: gold conversion and reward message

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -219,7 +219,8 @@ function getCardById(id) {
         cardTemplate.cost,
         cardTemplate.description,
         cardTemplate.effect,
-        cardTemplate.rarity
+        cardTemplate.rarity,
+        cardTemplate.block
     );
     return newCard;
 }
@@ -235,7 +236,8 @@ function getRandomCard() {
         cardTemplate.cost,
         cardTemplate.description,
         cardTemplate.effect,
-        cardTemplate.rarity
+        cardTemplate.rarity,
+        cardTemplate.block
     );
 }
 
@@ -278,7 +280,8 @@ function getRandomCardByRarity(rarity) {
         cardTemplate.cost,
         cardTemplate.description,
         cardTemplate.effect,
-        cardTemplate.rarity
+        cardTemplate.rarity,
+        cardTemplate.block
     );
 }
 

--- a/game.js
+++ b/game.js
@@ -35,6 +35,9 @@ class CardGame {
         this.eventCardForSale = null;
         this.eventCardCost = 0;
 
+        // Track gold at the start of each battle
+        this.goldAtBattleStart = this.gold;
+
         // Pending rewards or damage to apply when the player continues
         this.pendingGold = 0;
         this.pendingHp = 0;
@@ -235,6 +238,7 @@ class CardGame {
         this.gold = 100;
         this.pendingGold = 0;
         this.pendingHp = 0;
+        this.goldAtBattleStart = this.gold;
         this.updateGoldDisplay();
         
         this.titleScreen.classList.add('hidden');
@@ -337,6 +341,9 @@ class CardGame {
         this.playerEnergy = this.playerMaxEnergy;
         this.playerBlock = 0;
         this.playerStatuses = {};
+
+        // Track gold gained during this battle
+        this.goldAtBattleStart = this.gold;
         
         // Get a random enemy
         this.currentEnemy = getRandomEnemy();
@@ -925,7 +932,8 @@ class CardGame {
         this.playerSection.classList.add('hidden');
         this.pendingGold = 0;
         this.pendingHp = 0;
-        this.rewardTextElement.textContent = 'No gold reward.';
+        const goldGained = this.gold - this.goldAtBattleStart;
+        this.rewardTextElement.textContent = `Gold gained: ${goldGained}`;
     }
     
     // Add a card to player's collection and deck if space allows


### PR DESCRIPTION
## Summary
- ensure cloned cards keep their block value
- track gold at the start of battles
- show how much gold was gained after a win

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686645205e14832c8d96508ef79fe810