### PR TITLE
Add animation for defensive card gold conversion

### DIFF
--- a/game.js
+++ b/game.js
@@ -591,6 +591,18 @@ class CardGame {
         // Remove from hand
         const playedCard = this.hand.splice(cardIndex, 1)[0];
 
+        // Find the card element in the hand for animation
+        const cardElements = this.handContainer.querySelectorAll('.card');
+        const cardElement = Array.from(cardElements).find(elem => elem.dataset.cardId == playedCard.id);
+
+        // Animate the card moving toward the gold display (to the left)
+        if (cardElement && this.goldDisplay) {
+            const goldRect = this.goldDisplay.getBoundingClientRect();
+            const targetX = goldRect.left + goldRect.width / 2;
+            const targetY = goldRect.top + goldRect.height / 2;
+            animateCardPlayed(cardElement, targetX, targetY);
+        }
+
         // Pay energy cost
         this.playerEnergy -= playedCard.cost;
 


### PR DESCRIPTION
## Summary
- animate right-click action when converting a defensive card to gold

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68664772d7f4832c8752bae4017ef595