### PR TITLE
Ajout quêtes et effets de tour ennemi

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
         </div>
 
         <div id="battle-log" class="hidden"></div>
+        <div id="quest-container" class="hidden"></div>
+        <div id="enemy-turn-indicator" class="hidden">Enemy Turn</div>
 
         <div id="reward-screen" class="hidden">
             <h2>Victory!</h2>
@@ -166,6 +168,12 @@
                 <button id="event-buy" class="hidden">Buy</button>
                 <button id="event-skip" class="hidden">Skip</button>
                 <button id="event-continue">Continue</button>
+                <button id="event-quest1" class="hidden">Quest 1</button>
+                <button id="event-quest2" class="hidden">Quest 2</button>
+                <button id="event-quest3" class="hidden">Quest 3</button>
+                <button id="event-quest-skip" class="hidden">Ignore</button>
+                <button id="event-cancel1" class="hidden">Cancel</button>
+                <button id="event-cancel2" class="hidden">Cancel</button>
             </div>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -210,6 +210,52 @@ body {
     z-index: 1000;
 }
 
+#quest-container {
+    position: fixed;
+    top: 20px;
+    right: 220px;
+    width: 200px;
+    background: rgba(0, 0, 0, 0.7);
+    padding: 8px;
+    border-radius: 5px;
+    color: #fff;
+    font-size: 0.9rem;
+    z-index: 1000;
+}
+
+.quest-entry {
+    margin-bottom: 5px;
+}
+
+.quest-entry.completed {
+    text-decoration: line-through;
+    color: #a0aec0;
+}
+
+#enemy-turn-indicator {
+    position: fixed;
+    top: 40%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255, 0, 0, 0.8);
+    color: white;
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-size: 2rem;
+    pointer-events: none;
+    opacity: 0;
+    z-index: 2000;
+}
+
+.enemy-turn-show {
+    animation: enemy-turn-fade 1s forwards;
+}
+
+@keyframes enemy-turn-fade {
+    0% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
 #player-section {
     position: fixed;
     bottom: 20px;


### PR DESCRIPTION
## Summary
- add quest container and enemy turn indicator elements
- style quest list and enemy turn overlay
- implement quest system with nine quests and rewards
- add quest offering event and ability to cancel quests
- trigger visual and sound cues when enemy begins their turn

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_68668309fb64832ca1b562d7d327b22e